### PR TITLE
nginx-telemetry

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,6 +53,7 @@ nginx:
   mem_limit: 512m
   ports:
     - 80
+    - 9090
   env_file: _env
   labels:
     - triton.cns.services=nginx


### PR DESCRIPTION
open up the telemetry port following https://github.com/autopilotpattern/nginx/issues/10; a good companion to https://github.com/autopilotpattern/wordpress/pull/16
