### PR TITLE
Add placement (anti-)affinity

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 [![DockerPulls](https://img.shields.io/docker/pulls/autopilotpattern/wordpress.svg)](https://registry.hub.docker.com/u/autopilotpattern/wordpress/)
 [![DockerStars](https://img.shields.io/docker/stars/autopilotpattern/wordpress.svg)](https://registry.hub.docker.com/u/autopilotpattern/wordpress/)
 [![ImageLayers](https://badge.imagelayers.io/autopilotpattern/wordpress:latest.svg)](https://imagelayers.io/?images=autopilotpattern/wordpress:latest)
-[![Join the chat at https://gitter.im/autopilotpattern/general](https://badges.gitter.im/autopilotpattern/general.svg)](https://gitter.im/autopilotpattern/general)
 
 ---
 
@@ -168,12 +167,9 @@ This project has been fully tested and documented to run in Docker in local deve
 - [Kubernetes](http://kubernetes.io)
 - Others
 
-Discussion about support for these and other container platforms is welcome on [Gitter](https://gitter.im/autopilotpattern/general).
-
 ### Contributing
 
 - Please [report bugs in Github](https://github.com/autopilotpattern/wordpress/issues) (and check the bug list for known bugs)
-- Join us in [Gitter](https://gitter.im/autopilotpattern/general) to discuss features
 - It's open source, [pull requests welcome](https://github.com/autopilotpattern/wordpress/pulls)!
 
 ### Sponsors

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,10 @@ wordpress:
     - 80
     - 9090
   labels:
+    # Setting the CNS service name
     - triton.cns.services=wordpress
+    # Soft anti-affinity to avoid other WordPress instances
+    - com.docker.swarm.affinities=["container!=~*wordpress*"]
 
 # NFS is used to store user uploads
 nfs:
@@ -22,6 +25,8 @@ nfs:
     - 2049
   labels:
     - triton.cns.services=nfs
+    # Soft anti-affinity to avoid all other containers
+    - com.docker.swarm.affinities=["container!=~*"]
 
 # The MySQL database will automatically cluster and scale
 # see https://www.joyent.com/blog/dbaas-simplicity-no-lock-in
@@ -34,6 +39,7 @@ mysql:
     - 3306
   labels:
     - triton.cns.services=mysql
+    - com.docker.swarm.affinities=["container!=~*mysql*"]
 
 # Memcached is a high performance object cache
 memcached:
@@ -45,10 +51,11 @@ memcached:
     - 11211
   labels:
     - triton.cns.services=memcached
+    - com.docker.swarm.affinities=["container!=~*memcached*"]
 
 # Nginx as a load-balancing tier and reverse proxy
 nginx:
-  image: autopilotpattern/wordpress-nginx:latest
+  image: autopilotpattern/wordpress-nginx:1.0.1
   restart: always
   mem_limit: 512m
   ports:
@@ -57,6 +64,7 @@ nginx:
   env_file: _env
   labels:
     - triton.cns.services=nginx
+    - com.docker.swarm.affinities=["container!=~*nginx*"]
 
 # Consul is the service catalog that helps discovery between the components
 consul:
@@ -78,3 +86,4 @@ consul:
     - 127.0.0.1
   labels:
     - triton.cns.services=consul
+    - com.docker.swarm.affinities=["container!=~*"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,7 @@ memcached:
 
 # Nginx as a load-balancing tier and reverse proxy
 nginx:
-  image: autopilotpattern/wordpress-nginx:1.0.1
+  image: autopilotpattern/wordpress-nginx:latest
   restart: always
   mem_limit: 512m
   ports:


### PR DESCRIPTION
Adds anti-affinity filters to the Compose file that are intended to help distribute the application components across different nodes. This is a soft filter, so provisioning won't fail if the filter can't be satisfied.
