### PR TITLE
Eliminate risk of split brain

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,12 +77,14 @@ nginx:
     - com.docker.swarm.affinities=["container!=~*nginx*"]
 
 # Consul is the service catalog that helps discovery between the components
+# Change "-bootstrap" to "-bootstrap-expect 3", then scale to 3 or more to 
+# turn this into an HA Consul raft.
 consul:
   image: autopilotpattern/consul:latest
   command: >
     /usr/local/bin/containerpilot
     /bin/consul agent -server
-    -bootstrap-expect 1
+    -bootstrap
     -config-dir=/etc/consul
     -ui-dir /ui
   restart: always


### PR DESCRIPTION
There was a risk of a Consul split brain in https://github.com/autopilotpattern/wordpress/pull/23 that's fixed in this. The fix here makes it easy to run a single instance (non-HA) Consul, but requires a small change to the Docker Compose file in order to run as a multi-node HA raft.
