### PR TITLE
Add Prometheus to collect and view ContainerPilot telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ A running cluster includes the following components:
 - [NFS](https://github.com/autpilotpattern/nfsserver/): stores user uploaded files so these files can be shared between many WordPress containers
 - [Consul](https://www.consul.io/): used to coordinate replication and failover
 - [Manta](https://www.joyent.com/object-storage): the Joyent object store, for securely and durably storing our MySQL snapshots
+- [Prometheus](https://github.com/autopilotpattern/prometheus): an optional, [open source monitoring tool](https://prometheus.io) that tracks the performance of each component and demonstrates [ContainerPilot telemetry](https://www.joyent.com/blog/containerpilot-telemetry)
 - [WP-CLI](http://wp-cli.org/): to make managing WordPress easier
 
 ### How do I use this thing?

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,28 @@ wordpress:
     # Soft anti-affinity to avoid other WordPress instances
     - com.docker.swarm.affinities=["container!=~*wordpress*"]
 
+# Consul is the service catalog that helps discovery between the components
+# Change "-bootstrap" to "-bootstrap-expect 3", then scale to 3 or more to 
+# turn this into an HA Consul raft.
+consul:
+  image: autopilotpattern/consul:latest
+  command: >
+    /usr/local/bin/containerpilot
+    /bin/consul agent -server
+    -bootstrap
+    -config-dir=/etc/consul
+    -ui-dir /ui
+  restart: always
+  mem_limit: 128m
+  env_file: _env
+  ports:
+    - 8500
+  dns:
+    - 127.0.0.1
+  labels:
+    - triton.cns.services=consul
+    - com.docker.swarm.affinities=["container!=~*"]
+
 # NFS is used to store user uploads
 nfs:
   image: autopilotpattern/nfsserver:latest
@@ -76,24 +98,15 @@ nginx:
     - triton.cns.services=nginx
     - com.docker.swarm.affinities=["container!=~*nginx*"]
 
-# Consul is the service catalog that helps discovery between the components
-# Change "-bootstrap" to "-bootstrap-expect 3", then scale to 3 or more to 
-# turn this into an HA Consul raft.
-consul:
-  image: autopilotpattern/consul:latest
-  command: >
-    /usr/local/bin/containerpilot
-    /bin/consul agent -server
-    -bootstrap
-    -config-dir=/etc/consul
-    -ui-dir /ui
+# Prometheus is an open source performance monitoring tool
+# it is included here for demo purposes and is not required
+prometheus:
+  image: autopilotpattern/prometheus:latest
   restart: always
-  mem_limit: 128m
+  mem_limit: 1g
   env_file: _env
   ports:
-    - 8500
-  dns:
-    - 127.0.0.1
+    - 9090
   labels:
-    - triton.cns.services=consul
-    - com.docker.swarm.affinities=["container!=~*"]
+    - triton.cns.services=prometheus
+    - com.docker.swarm.affinities=["container!=~*prometheus*"]

--- a/local-compose.yml
+++ b/local-compose.yml
@@ -1,3 +1,5 @@
+# See docker-compose.yml for further descriptions and configuration details of each service
+
 wordpress:
   extends:
     file: docker-compose.yml
@@ -11,6 +13,14 @@ wordpress:
     - consul:consul
   ports:
     - "80"
+
+consul:
+  extends:
+    file: docker-compose.yml
+    service: consul
+  restart: never
+  ports:
+    - 8500:8500
 
 nfs:
   extends:
@@ -49,7 +59,6 @@ memcached:
   links:
     - consul:consul
 
-# Nginx as a load-balancing tier and reverse proxy
 nginx:
   extends:
     file: docker-compose.yml
@@ -63,10 +72,14 @@ nginx:
   ports:
     - 80:80
 
-consul:
+prometheus:
   extends:
     file: docker-compose.yml
-    service: consul
+    service: prometheus
   restart: never
+  environment:
+    - CONSUL=consul
+  links:
+    - consul:consul
   ports:
-    - 8500:8500
+    - 9090:9090


### PR DESCRIPTION
This PR adds Prometheus to the Docker Compose file so we can easily demo ContainerPilot telemetry in this composition.
