### PR TITLE
X_FORWARDED_PROTO & WP ssl fixing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 # An demo version of WordPress for easy scaling
 wordpress:
-  image: autopilotpattern/wordpress:latest
+  #image: autopilotpattern/wordpress:latest
+  image: jasondewitt/autopilotwordpress:latest
+  #build: .
   restart: always
   mem_limit: 1g
   env_file: _env
@@ -16,7 +18,7 @@ wordpress:
     - com.docker.swarm.affinities=["container!=~*wordpress*"]
 
 # Consul is the service catalog that helps discovery between the components
-# Change "-bootstrap" to "-bootstrap-expect 3", then scale to 3 or more to 
+# Change "-bootstrap" to "-bootstrap-expect 3", then scale to 3 or more to
 # turn this into an HA Consul raft.
 consul:
   image: autopilotpattern/consul:latest
@@ -85,7 +87,8 @@ memcached:
 
 # Nginx as a load-balancing tier and reverse proxy
 nginx:
-  image: autopilotpattern/wordpress-nginx:branch-jasonpincin-issue-33
+  #image: autopilotpattern/wordpress-nginx:branch-jasonpincin-issue-33
+  image: jasondewitt/wordpress-nginx:branch-wpsslfix
   restart: always
   mem_limit: 512m
   ports:

--- a/nginx/etc/nginx/nginx-ssl.conf.ctmpl
+++ b/nginx/etc/nginx/nginx-ssl.conf.ctmpl
@@ -85,11 +85,12 @@ http {
 
         {{ if service "wordpress" }}
         rewrite ^/wp-admin/?(.*) /wordpress/wp-admin/$1;
-        
+
         location ^~ / {
             proxy_pass http://wordpress;
             proxy_set_header Host $http_host;
             proxy_redirect off;
+            proxy_set_header X-Forwarded-Proto $scheme;
         }{{end}}
     }
 }

--- a/nginx/etc/nginx/nginx.conf.ctmpl
+++ b/nginx/etc/nginx/nginx.conf.ctmpl
@@ -60,11 +60,12 @@ http {
 
         {{ if service "wordpress" }}
         rewrite ^/wp-admin/?(.*) /wordpress/wp-admin/$1;
-        
+
         location ^~ / {
             proxy_pass http://wordpress;
             proxy_set_header Host $http_host;
             proxy_redirect off;
+            proxy_set_header X-Forwarded-Proto $scheme;
         }{{end}}
     }
 }

--- a/var/www/html/wp-config.php.ctmpl
+++ b/var/www/html/wp-config.php.ctmpl
@@ -19,6 +19,12 @@ define( 'DB_PASSWORD', '{{env "MYSQL_PASSWORD"}}' );
 define( 'DB_HOST',     '{{if service "mysql-primary"}}{{with index (service "mysql-primary") 0}}{{.Address}}:{{.Port}}{{end}}{{end}}' );
 
 /**
+ * Handle SSL reverse proxy
+ */
+if ($_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https')
+    $_SERVER['HTTPS']='on';
+    
+/**
  * Custom Content Directory
  */
 define( 'WP_CONTENT_DIR', dirname( __FILE__ ) . '/content' );


### PR DESCRIPTION
added setting a X_FORWARDED_PROTO to the WordPress proxy pass location blocks

added code to wp-config.php to pick up that header and set $_SERVER['HTTPS']='on'

docker-compose.yml still contains refrences to the images I built from these files and pushed to my dockerhub.
